### PR TITLE
fix: change board type for wf2

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -33,7 +33,7 @@ lib_deps =
 
 [env:huidu_hd_wf2]
 platform = https://github.com/Jason2866/platform-espressif32.git#Arduino/IDF53
-board = huidu_hd_wf2
+board = esp32-s3-devkitc-1
 framework = arduino
 monitor_speed = 115200
 build_flags = ${common.build_flags}

--- a/src/hd-wf2-esp32s3-config.h
+++ b/src/hd-wf2-esp32s3-config.h
@@ -4,7 +4,7 @@
 //       You can only use wither the 75EX1 or 75EX1 port at any time to drive a single HUB75 panel, or a chain of panels.
 
 #define RUN_LED_PIN       40
-#define PUSH_BUTTON_PIN   11
+#define PUSH_BUTTON_PIN   17
 
 // I2C RTC BM8563 I2C port
 #define BM8563_I2C_SDA    41


### PR DESCRIPTION
- changed board type for `env:huidu_hd_wf2` configuration. Previous board did not work anymore:
```
Compiling .pio\build\huidu_hd_wf2\libb9d\Wire\Wire.cpp.o
Compiling .pio\build\huidu_hd_wf2\lib6da\I2C BM8563 RTC\I2C_BM8563.cpp.o
In file included from C:/Users/filip/.platformio/packages/toolchain-xtensa-esp-elf/xtensa-esp-elf/include/sys/reent.h:34,
libs/esp32s3/include/newlib/platform_include/sys/lock.h:9:10: fatal error: sdkconfig.h: No such file or directory

*******************************************************************
* Looking for sdkconfig.h dependency? Check our library registry!
*
* CLI  > platformio lib search "header:sdkconfig.h"
* Web  > https://registry.platformio.org/search?q=header:sdkconfig.h
*
*******************************************************************

    9 | #include "sdkconfig.h"
      |          ^~~~~~~~~~~~~
compilation terminated.
Compiling .pio\build\huidu_hd_wf2\lib383\ESP32Time\ESP32Time.cpp.o
```
- set correct button pin for wf2, previous configuration used incorrect pin